### PR TITLE
Fix: Support earlier versions of Poison

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.4.1
+erlang 19.2

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # Accounting
+[![CircleCI](https://circleci.com/gh/spartansystems/accounting/tree/master.svg?style=svg&circle-token=dcede0074988c9ad4736073c3e6c7200a0e7060c)]

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,20 @@
+machine:
+  environment:
+    PATH: "$HOME/.asdf/bin:$HOME/.asdf/shims:$PATH"
+    MIX_ENV: "test"
+dependencies:
+  cache_directories:
+    - ~/.asdf
+  pre:
+    - if ! asdf | grep version; then git clone https://github.com/HashNuke/asdf.git ~/.asdf; fi
+    - if ! asdf list erlang; then asdf plugin-add erlang https://github.com/HashNuke/asdf-erlang.git; fi
+    - if ! asdf list elixir; then asdf plugin-add elixir https://github.com/HashNuke/asdf-elixir.git; fi
+    - erlang_version=$(awk '/erlang/ { print $2 }' .tool-versions) && asdf install erlang ${erlang_version}
+    - elixir_version=$(awk '/elixir/ { print $2 }' .tool-versions) && asdf install elixir ${elixir_version}
+    - mix local.hex --force
+    - mix local.rebar --force
+    - mix deps.get
+    - mix deps.compile
+test:
+  override:
+    - mix test

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.1.0",
+      version: "0.1.1",
       start_permanent: Mix.env === :prod,
     ]
   end
@@ -19,7 +19,7 @@ defmodule Accounting.Mixfile do
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:httpoison, "~> 0.9"},
       {:oauther, "~> 1.1.0"},
-      {:poison, "~> 3.0"},
+      {:poison, "~> 2.2 or ~> 3.0"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -7,5 +7,5 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "oauther": {:hex, :oauther, "1.1.0", "c9a56e200507ce64e069f5273143db0cddd7904cd5d1fe46920388a48f22441b", [:mix], []},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []}}


### PR DESCRIPTION
Closes #1 

Why:

* Many packages are locked on Poison 2.

How:

* Expand Poison version specification.
* Add continuous integration support.