### PR TITLE
Hotfix: Adapter config

### DIFF
--- a/lib/accounting.ex
+++ b/lib/accounting.ex
@@ -6,22 +6,24 @@ defmodule Accounting do
     sort_transactions: 1,
   ]
 
-  @adapter Application.get_env(:accounting, :adapter, Accounting.TestAdapter)
+  def register_categories(categories) do
+    adapter().register_categories(categories)
+  end
 
-  defdelegate register_categories(categories), to: @adapter
+  def create_account(number), do: adapter().create_account(number)
 
-  defdelegate create_account(number), to: @adapter
-
-  defdelegate receive_money(from, date, line_items), to: @adapter
+  def receive_money(from, date, line_items) do
+    adapter().receive_money(from, date, line_items)
+  end
 
   def fetch_account_transactions(account_number) do
-    with {:ok, txns} <- @adapter.fetch_account_transactions(account_number) do
+    with {:ok, txns} <- adapter().fetch_account_transactions(account_number) do
       {:ok, sort_transactions(txns)}
     end
   end
 
   def fetch_balance(account_number) do
-    with {:ok, txns} <- @adapter.fetch_account_transactions(account_number) do
+    with {:ok, txns} <- adapter().fetch_account_transactions(account_number) do
       {:ok, calculate_balance(txns)}
     end
   end
@@ -37,4 +39,6 @@ defmodule Accounting do
       {:ok, calculate_ADB!(transactions, start_date, end_date)}
     end
   end
+
+  defp adapter, do: Application.fetch_env!(:accounting, :adapter)
 end

--- a/lib/accounting/application.ex
+++ b/lib/accounting/application.ex
@@ -1,17 +1,19 @@
 defmodule Accounting.Application do
   use Application
 
-  @moduledoc false
+  alias Accounting.TestAdapter
 
-  @adapter Application.get_env(:accounting, :adapter, Accounting.TestAdapter)
+  @moduledoc false
 
   ## Callbacks
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    Supervisor.start_link [worker(@adapter, [])],
+    Supervisor.start_link [worker(adapter(), [])],
       strategy: :one_for_one,
       name: Accounting.Supervisor
   end
+
+  defp adapter, do: Application.get_env(:accounting, :adapter, TestAdapter)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.1.1",
+      version: "0.1.2",
       start_permanent: Mix.env === :prod,
     ]
   end

--- a/test/accounting/helpers_test.exs
+++ b/test/accounting/helpers_test.exs
@@ -2,6 +2,8 @@ defmodule Accounting.HelpersTest do
   use ExUnit.Case, async: true
   doctest Accounting.Helpers
 
+  Application.put_env(:accounting, :adapter, Accounting.TestAdapter)
+
   alias Accounting.{AccountTransaction, Helpers}
 
   describe "calculate_balance/1" do


### PR DESCRIPTION
Why:

* Adapter config changes weren’t picked up after Accounting was compiled.

How:

* Fetch the `:adapter` config var when it’s used instead of during compilation.