### PR TITLE
Address Xero rate-limit

### DIFF
--- a/lib/accounting/adapters/xero_adapter.ex
+++ b/lib/accounting/adapters/xero_adapter.ex
@@ -1,8 +1,10 @@
 defmodule Accounting.XeroAdapter do
-  @behaviour Accounting.Adapter
-
   alias Accounting.AccountTransaction
   import Accounting.XeroView, only: [render: 1, render: 2]
+
+  @behaviour Accounting.Adapter
+
+  @rate_limit_delay 1_000
 
   ## Callbacks
 
@@ -174,6 +176,7 @@ defmodule Accounting.XeroAdapter do
         transactions = Enum.reduce(journals, acc, &import_journal/2)
 
         if length(journals) === 100 do
+          Process.sleep(@rate_limit_delay)
           fetch_new(offset + 100, transactions)
         else
           {:ok, transactions, next_offset(journals) || offset}

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.2.0",
+      version: "0.2.1",
       start_permanent: Mix.env === :prod,
     ]
   end


### PR DESCRIPTION
Why:

* Xero limits calls to 60 per minute. Fetching account transactions could exceed that limit given enough transactions in Xero.

How:

* Add 1 second delay between API calls to retrieve journals from Xero.