### PR TITLE
Ignore zero-amount line items while moving money

### DIFF
--- a/lib/accounting.ex
+++ b/lib/accounting.ex
@@ -6,38 +6,50 @@ defmodule Accounting do
     sort_transactions: 1,
   ]
 
+  @spec register_categories(list(atom)) :: :ok | {:error, any}
   def register_categories(categories) do
     adapter().register_categories(categories)
   end
 
+  @spec create_account(binary) :: :ok | {:error, any}
   def create_account(number), do: adapter().create_account(number)
 
+  @spec receive_money(binary, Date.t, list(Accounting.LineItem.t)) :: :ok | {:error, any}
   def receive_money(from, date, line_items) do
-    adapter().receive_money(from, date, line_items)
+    adapter().receive_money(from, date, filter_line_items(line_items))
   end
 
+  @spec spend_money(binary, Date.t, list(Accounting.LineItem.t)) :: :ok | {:error, any}
   def spend_money(to, date, line_items) do
-    adapter().spend_money(to, date, line_items)
+    adapter().spend_money(to, date, filter_line_items(line_items))
   end
 
+  defp filter_line_items(line_items) do
+    for i <- line_items, i.amount !== 0, do: i
+  end
+
+  @spec fetch_account_transactions(binary) :: {:ok, list(Accounting.AccountTransaction.t)} | {:error, any}
   def fetch_account_transactions(account_number) do
     with {:ok, txns} <- adapter().fetch_account_transactions(account_number) do
       {:ok, sort_transactions(txns)}
     end
   end
 
+  @spec fetch_balance(binary) :: {:ok, integer} | {:error, any}
   def fetch_balance(account_number) do
     with {:ok, txns} <- adapter().fetch_account_transactions(account_number) do
       {:ok, calculate_balance(txns)}
     end
   end
 
+  @spec fetch_balance(binary, Date.t) :: {:ok, integer} | {:error, any}
   def fetch_balance(account_number, date) do
     with {:ok, transactions} <- fetch_account_transactions(account_number) do
       {:ok, calculate_balance!(transactions, date)}
     end
   end
 
+  @spec fetch_ADB(binary, Date.t, Date.t) :: {:ok, integer} | {:error, any}
   def fetch_ADB(account_number, start_date, end_date) do
     with {:ok, transactions} <- fetch_account_transactions(account_number) do
       {:ok, calculate_ADB!(transactions, start_date, end_date)}

--- a/lib/accounting/adapters/test_adapter.ex
+++ b/lib/accounting/adapters/test_adapter.ex
@@ -1,6 +1,8 @@
 defmodule Accounting.TestAdapter do
   @behaviour Accounting.Adapter
 
+  @moduledoc false
+
   alias Accounting.AccountTransaction
 
   def reset, do: Agent.update(__MODULE__, fn _ -> %{} end)

--- a/lib/accounting/adapters/xero_adapter.ex
+++ b/lib/accounting/adapters/xero_adapter.ex
@@ -2,6 +2,8 @@ defmodule Accounting.XeroAdapter do
   alias Accounting.AccountTransaction
   import Accounting.XeroView, only: [render: 1, render: 2]
 
+  @moduledoc false
+
   @behaviour Accounting.Adapter
 
   @rate_limit_delay 1_000

--- a/lib/accounting/assertions.ex
+++ b/lib/accounting/assertions.ex
@@ -3,6 +3,7 @@ defmodule Accounting.Assertions do
 
   @timeout 100
 
+  @spec assert_registered_category(binary) :: true | no_return
   def assert_registered_category(category) do
     receive do
       {:registered_category, ^category} -> true
@@ -12,6 +13,7 @@ defmodule Accounting.Assertions do
     end
   end
 
+  @spec assert_created_account(binary) :: true | no_return
   def assert_created_account(number) do
     receive do
       {:created_account, ^number} -> true
@@ -21,6 +23,7 @@ defmodule Accounting.Assertions do
     end
   end
 
+  @spec assert_received_money_with_line_item(binary, Date.t, list(Accounting.LineItem.t)) :: true | no_return
   def assert_received_money_with_line_item(from, date, line_item) do
     receive do
       {:received_money, ^from, ^date, ^line_item} -> true
@@ -34,6 +37,7 @@ defmodule Accounting.Assertions do
     end
   end
 
+  @spec refute_received_money(binary, Date.t) :: true | no_return
   def refute_received_money(from, date) do
     receive do
       {:received_money, ^from, ^date, _} ->
@@ -43,6 +47,7 @@ defmodule Accounting.Assertions do
     end
   end
 
+  @spec assert_spent_money_with_line_item(binary, Date.t, list(Accounting.LineItem.t)) :: true | no_return
   def assert_spent_money_with_line_item(to, date, line_item) do
     receive do
       {:spent_money, ^to, ^date, ^line_item} -> true
@@ -56,6 +61,7 @@ defmodule Accounting.Assertions do
     end
   end
 
+  @spec refute_spent_money(binary, Date.t) :: true | no_return
   def refute_spent_money(to, date) do
     receive do
       {:spent_money, ^to, ^date, _} ->

--- a/lib/accounting/helpers.ex
+++ b/lib/accounting/helpers.ex
@@ -1,4 +1,6 @@
 defmodule Accounting.Helpers do
+  @moduledoc false
+
   def calculate_balance(account_transactions) do
     Enum.reduce(account_transactions, 0, & &1.amount + &2)
   end

--- a/lib/accounting/structs/account_transaction.ex
+++ b/lib/accounting/structs/account_transaction.ex
@@ -1,3 +1,5 @@
 defmodule Accounting.AccountTransaction do
+  @type t :: %Accounting.AccountTransaction{}
+
   defstruct [:amount, :description, :date]
 end

--- a/lib/accounting/structs/line_item.ex
+++ b/lib/accounting/structs/line_item.ex
@@ -1,3 +1,5 @@
 defmodule Accounting.LineItem do
+  @type t :: %Accounting.LineItem{}
+
   defstruct [:description, :amount, :account_number, category: :other]
 end

--- a/lib/accounting/views/xero_view.ex
+++ b/lib/accounting/views/xero_view.ex
@@ -1,4 +1,6 @@
 defmodule Accounting.XeroView do
+  @moduledoc false
+
   def render("start_link.xml") do
     """
     <TrackingCategories>

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.2.1",
+      version: "0.2.2",
       start_permanent: Mix.env === :prod,
     ]
   end


### PR DESCRIPTION
Why
---

* Zero-amount line items are nonsensical.

How
---

* Reject them when receiving or sending money.

Also
----

* Add typespecs.