### PR TITLE
Feature: Timeout Parameters

### DIFF
--- a/lib/accounting.ex
+++ b/lib/accounting.ex
@@ -6,55 +6,59 @@ defmodule Accounting do
     sort_transactions: 1,
   ]
 
-  @spec register_categories(list(atom)) :: :ok | {:error, any}
-  def register_categories(categories) do
-    adapter().register_categories(categories)
+  @default_timeout 5_000
+
+  @spec register_categories([atom], timeout) :: :ok | {:error, any}
+  def register_categories(categories, timeout \\ @default_timeout) do
+    adapter().register_categories(categories, timeout)
   end
 
-  @spec create_account(binary) :: :ok | {:error, any}
-  def create_account(number), do: adapter().create_account(number)
+  @spec create_account(String.t, timeout) :: :ok | {:error, any}
+  def create_account(number, timeout \\ @default_timeout), do: adapter().create_account(number, timeout)
 
-  @spec receive_money(binary, Date.t, list(Accounting.LineItem.t)) :: :ok | {:error, any}
-  def receive_money(from, date, line_items) do
-    adapter().receive_money(from, date, filter_line_items(line_items))
+  @spec receive_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
+  def receive_money(from, date, line_items, timeout \\ @default_timeout) do
+    adapter().receive_money(from, date, filter_line_items(line_items), timeout)
   end
 
-  @spec spend_money(binary, Date.t, list(Accounting.LineItem.t)) :: :ok | {:error, any}
-  def spend_money(to, date, line_items) do
-    adapter().spend_money(to, date, filter_line_items(line_items))
+  @spec spend_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
+  def spend_money(to, date, line_items, timeout \\ @default_timeout) do
+    adapter().spend_money(to, date, filter_line_items(line_items), timeout)
   end
 
+  @spec filter_line_items([Accounting.LineItem.t]) :: [Accounting.LineItem.t]
   defp filter_line_items(line_items) do
     for i <- line_items, i.amount !== 0, do: i
   end
 
-  @spec fetch_account_transactions(binary) :: {:ok, list(Accounting.AccountTransaction.t)} | {:error, any}
-  def fetch_account_transactions(account_number) do
-    with {:ok, txns} <- adapter().fetch_account_transactions(account_number) do
-      {:ok, sort_transactions(txns)}
-    end
+  @spec fetch_account_transactions(String.t, timeout) :: {:ok, [Accounting.AccountTransaction.t]} | {:error, any}
+  def fetch_account_transactions(account_number, timeout \\ @default_timeout) do
+    response = adapter().fetch_account_transactions(account_number, timeout)
+    with {:ok, txns} <- response, do: {:ok, sort_transactions(txns)}
   end
 
-  @spec fetch_balance(binary) :: {:ok, integer} | {:error, any}
-  def fetch_balance(account_number) do
-    with {:ok, txns} <- adapter().fetch_account_transactions(account_number) do
-      {:ok, calculate_balance(txns)}
-    end
+  @spec fetch_balance(String.t, timeout) :: {:ok, integer} | {:error, any}
+  def fetch_balance(account_number, timeout \\ @default_timeout) do
+    response = adapter().fetch_account_transactions(account_number, timeout)
+    with {:ok, txns} <- response, do: {:ok, calculate_balance(txns)}
   end
 
-  @spec fetch_balance(binary, Date.t) :: {:ok, integer} | {:error, any}
-  def fetch_balance(account_number, date) do
-    with {:ok, transactions} <- fetch_account_transactions(account_number) do
+  @spec fetch_balance_on_date(String.t, Date.t, timeout) :: {:ok, integer} | {:error, any}
+  def fetch_balance_on_date(account_number, date, timeout \\ @default_timeout) do
+    response = fetch_account_transactions(account_number, timeout)
+    with {:ok, transactions} <- response do
       {:ok, calculate_balance!(transactions, date)}
     end
   end
 
-  @spec fetch_ADB(binary, Date.t, Date.t) :: {:ok, integer} | {:error, any}
-  def fetch_ADB(account_number, start_date, end_date) do
-    with {:ok, transactions} <- fetch_account_transactions(account_number) do
+  @spec fetch_ADB(String.t, Date.t, Date.t, timeout) :: {:ok, integer} | {:error, any}
+  def fetch_ADB(account_number, start_date, end_date, timeout \\ @default_timeout) do
+    response = fetch_account_transactions(account_number, timeout)
+    with {:ok, transactions} <- response do
       {:ok, calculate_ADB!(transactions, start_date, end_date)}
     end
   end
 
+  @spec adapter() :: module
   defp adapter, do: Application.fetch_env!(:accounting, :adapter)
 end

--- a/lib/accounting/adapter.ex
+++ b/lib/accounting/adapter.ex
@@ -1,8 +1,8 @@
 defmodule Accounting.Adapter do
   @callback start_link() :: Supervisor.on_start
-  @callback register_categories(list(atom)) :: :ok | {:error, any}
-  @callback create_account(binary) :: :ok | {:error, any}
-  @callback receive_money(binary, Date.t, list(Accounting.LineItem.t)) :: :ok | {:error, any}
-  @callback spend_money(binary, Date.t, list(Accounting.LineItem.t)) :: :ok | {:error, any}
-  @callback fetch_account_transactions(binary) :: {:ok, list(Accounting.AccountTransaction.t)} | {:error, any}
+  @callback register_categories([atom], timeout) :: :ok | {:error, any}
+  @callback create_account(String.t, timeout) :: :ok | {:error, any}
+  @callback receive_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
+  @callback spend_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
+  @callback fetch_account_transactions(String.t, timeout) :: {:ok, [Accounting.AccountTransaction.t]} | {:error, any}
 end

--- a/lib/accounting/adapters/test_adapter.ex
+++ b/lib/accounting/adapters/test_adapter.ex
@@ -11,13 +11,13 @@ defmodule Accounting.TestAdapter do
 
   def start_link, do: Agent.start_link(&Map.new/0, name: __MODULE__)
 
-  def register_categories(categories) do
+  def register_categories(categories, _timeout) do
     Enum.each categories, fn category ->
       send self(), {:registered_category, category}
     end
   end
 
-  def create_account(number) do
+  def create_account(number, _timeout) do
     send self(), {:created_account, number}
 
     if exists?(number) do
@@ -31,7 +31,7 @@ defmodule Accounting.TestAdapter do
     Agent.get(__MODULE__, &Map.has_key?(&1, account_number))
   end
 
-  def receive_money(<<_::binary>> = from, %Date{} = date, [_|_] = line_items) do
+  def receive_money(<<_::binary>> = from, %Date{} = date, [_|_] = line_items, _timeout) do
     Enum.each line_items, fn item ->
       send self(), {:received_money, from, date, item}
     end
@@ -53,7 +53,7 @@ defmodule Accounting.TestAdapter do
     end
   end
 
-  def spend_money(<<_::binary>> = to, %Date{} = date, [_|_] = line_items) do
+  def spend_money(<<_::binary>> = to, %Date{} = date, [_|_] = line_items, _timeout) do
     Enum.each line_items, fn item ->
       send self(), {:spent_money, to, date, item}
     end
@@ -81,7 +81,7 @@ defmodule Accounting.TestAdapter do
     end
   end
 
-  def fetch_account_transactions(number) do
+  def fetch_account_transactions(number, _timeout) do
     {:ok, get_account_transactions(number)}
   end
 

--- a/lib/accounting/assertions.ex
+++ b/lib/accounting/assertions.ex
@@ -3,7 +3,7 @@ defmodule Accounting.Assertions do
 
   @timeout 100
 
-  @spec assert_registered_category(binary) :: true | no_return
+  @spec assert_registered_category(String.t) :: true | no_return
   def assert_registered_category(category) do
     receive do
       {:registered_category, ^category} -> true
@@ -13,7 +13,7 @@ defmodule Accounting.Assertions do
     end
   end
 
-  @spec assert_created_account(binary) :: true | no_return
+  @spec assert_created_account(String.t) :: true | no_return
   def assert_created_account(number) do
     receive do
       {:created_account, ^number} -> true
@@ -23,7 +23,7 @@ defmodule Accounting.Assertions do
     end
   end
 
-  @spec assert_received_money_with_line_item(binary, Date.t, list(Accounting.LineItem.t)) :: true | no_return
+  @spec assert_received_money_with_line_item(String.t, Date.t, [Accounting.LineItem.t]) :: true | no_return
   def assert_received_money_with_line_item(from, date, line_item) do
     receive do
       {:received_money, ^from, ^date, ^line_item} -> true
@@ -37,7 +37,7 @@ defmodule Accounting.Assertions do
     end
   end
 
-  @spec refute_received_money(binary, Date.t) :: true | no_return
+  @spec refute_received_money(String.t, Date.t) :: true | no_return
   def refute_received_money(from, date) do
     receive do
       {:received_money, ^from, ^date, _} ->
@@ -47,7 +47,7 @@ defmodule Accounting.Assertions do
     end
   end
 
-  @spec assert_spent_money_with_line_item(binary, Date.t, list(Accounting.LineItem.t)) :: true | no_return
+  @spec assert_spent_money_with_line_item(String.t, Date.t, [Accounting.LineItem.t]) :: true | no_return
   def assert_spent_money_with_line_item(to, date, line_item) do
     receive do
       {:spent_money, ^to, ^date, ^line_item} -> true
@@ -61,7 +61,7 @@ defmodule Accounting.Assertions do
     end
   end
 
-  @spec refute_spent_money(binary, Date.t) :: true | no_return
+  @spec refute_spent_money(String.t, Date.t) :: true | no_return
   def refute_spent_money(to, date) do
     receive do
       {:spent_money, ^to, ^date, _} ->

--- a/lib/accounting/helpers.ex
+++ b/lib/accounting/helpers.ex
@@ -1,10 +1,12 @@
 defmodule Accounting.Helpers do
   @moduledoc false
 
+  @spec calculate_balance([AccountTransaction.t]) :: integer
   def calculate_balance(account_transactions) do
     Enum.reduce(account_transactions, 0, & &1.amount + &2)
   end
 
+  @spec calculate_balance!([AccountTransaction.t], Date.t) :: integer | no_return
   def calculate_balance!(account_transactions, date) do
     if sorted?(account_transactions) do
       do_calculate_balance(account_transactions, date)
@@ -13,6 +15,7 @@ defmodule Accounting.Helpers do
     end
   end
 
+  @spec do_calculate_balance([AccountTransaction.t], Date.t) :: integer
   defp do_calculate_balance(transactions, date) do
     {_, balance} =
       Enumerable.reduce transactions, {:cont, 0}, fn transaction, acc ->
@@ -26,6 +29,7 @@ defmodule Accounting.Helpers do
     balance
   end
 
+  @spec calculate_ADB!([AccountTransaction.t], Date.t, Date.t) :: integer | no_return
   def calculate_ADB!(account_transactions, start_date, end_date) do
     if sorted?(account_transactions) do
       account_transactions
@@ -37,6 +41,7 @@ defmodule Accounting.Helpers do
     end
   end
 
+  @spec sorted?([AccountTransaction.t]) :: boolean
   defp sorted?(transactions) do
     {result, _} =
       Enumerable.reduce transactions, {:cont, ~D[0000-01-01]}, fn
@@ -51,10 +56,12 @@ defmodule Accounting.Helpers do
     result === :done
   end
 
+  @spec sort_transactions([AccountTransaction.t]) :: [AccountTransaction.t]
   def sort_transactions(transactions) do
     Enum.sort(transactions, & diff(&1.date, &2.date) <= 0)
   end
 
+  @spec daily_balances([AccountTransaction.t], Date.t, Date.t) :: [integer]
   defp daily_balances(transactions, start_date, end_date) do
     {_, {last_date, balances}} =
       Enumerable.reduce transactions, {:cont, {start_date, [0]}}, fn
@@ -75,20 +82,24 @@ defmodule Accounting.Helpers do
     |> Enum.reverse()
   end
 
+  @spec diff(Date.t, Date.t) :: -30..30
   defp diff(start_date, end_date) do
     to_gregorian_days(start_date) - to_gregorian_days(end_date)
   end
 
+  @spec to_gregorian_days(Date.t) :: 1..31
   defp to_gregorian_days(date) do
     date
     |> Date.to_erl()
     |> :calendar.date_to_gregorian_days()
   end
 
+  @spec repeat_head([integer], integer) :: [integer]
   defp repeat_head([hd|_] = list, times) when times > 0 do
     Enum.reduce(1..times, list, fn _, acc -> [hd|acc] end)
   end
   defp repeat_head(list, _), do: list
 
+  @spec mean([integer]) :: float
   defp mean(list), do: Enum.reduce(list, 0, &Kernel.+/2) / length(list)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.2.2",
+      version: "0.3.0",
       start_permanent: Mix.env === :prod,
     ]
   end


### PR DESCRIPTION
Why
---

The consumer of this app may wish to set an arbitrary timeout for any given call.

How
---

* Add timeout parameter to all public functions in `Accounting`.
* Rename `fetch_balance/2` to `fetch_balance_on_date` with arities of 2 and 3.
* Update and add typespecs.

Side effects
------------

* Breaking API changes.