### PR TITLE
Fix: TLS

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :ssl, protocol_version: :"tlsv1.2"

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.3.0",
+      version: "0.3.1",
       start_permanent: Mix.env === :prod,
     ]
   end


### PR DESCRIPTION
Why
---

* OTP 19 has a bug with the SSL module and default protocol version it
  tries to use.

How
---

* Set SSL protocol to TLS v1.2.