### PR TITLE
Hotfix: Boot Time

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.3.1",
+      version: "0.3.2",
       start_permanent: Mix.env === :prod,
     ]
   end


### PR DESCRIPTION
Why
---

* Memoization in the Xero adapter was blocking boot, which could lead to excessive boot times.
* Address potential race condition in memoization while fetching account transactions.

How
---

* Move initial memoization into a cast.
* Move subsequent memoization calculation from client process to server process.

Side effects
------------

* Calls made shortly after boot may require a longer timeout, given that the memoization server will be busy.