### PR TITLE
Hotfix: Boot

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.3.2",
+      version: "0.3.3",
       start_permanent: Mix.env === :prod,
     ]
   end


### PR DESCRIPTION
Why
---

* The application was unable to boot with the Xero adapter.

How
---

* Return `on_start` tuple from `Accounting.Xero.Adapter.start_link/0`.
* Link memo process to adapter process instead of client process.