### PR TITLE
Create Account with Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Accounting
-[![CircleCI](https://circleci.com/gh/spartansystems/accounting/tree/master.svg?style=svg&circle-token=dcede0074988c9ad4736073c3e6c7200a0e7060c)]
+![CircleCI](https://circleci.com/gh/spartansystems/accounting/tree/master.svg?style=svg&circle-token=dcede0074988c9ad4736073c3e6c7200a0e7060c)
+
+Accounting in Elixir.

--- a/lib/accounting.ex
+++ b/lib/accounting.ex
@@ -13,8 +13,8 @@ defmodule Accounting do
     adapter().register_categories(categories, timeout)
   end
 
-  @spec create_account(String.t, timeout) :: :ok | {:error, any}
-  def create_account(number, timeout \\ @default_timeout), do: adapter().create_account(number, timeout)
+  @spec create_account(String.t, String.t, timeout) :: :ok | {:error, any}
+  def create_account(number, description, timeout \\ @default_timeout), do: adapter().create_account(number, description, timeout)
 
   @spec receive_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
   def receive_money(from, date, line_items, timeout \\ @default_timeout) do

--- a/lib/accounting/adapters/test_adapter.ex
+++ b/lib/accounting/adapters/test_adapter.ex
@@ -17,7 +17,7 @@ defmodule Accounting.TestAdapter do
     end
   end
 
-  def create_account(number, _timeout) do
+  def create_account(number, _description, _timeout) do
     send self(), {:created_account, number}
 
     if exists?(number) do

--- a/lib/accounting/views/xero_view.ex
+++ b/lib/accounting/views/xero_view.ex
@@ -116,7 +116,7 @@ defmodule Accounting.XeroView do
     """
     <Account>
       <Code>#{xml_escape assigns[:number]}</Code>
-      <Name>#{xml_escape assigns[:number]}</Name>
+      <Name>#{xml_escape assigns[:name]}</Name>
       <Type>CURRLIAB</Type>
     </Account>
     """

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.3.3",
+      version: "0.4.0",
       start_permanent: Mix.env === :prod,
     ]
   end


### PR DESCRIPTION
Job Story Card
--------------

- [Story Card](https://www.pivotaltracker.com/story/show/142965653)

Why
---

- When creating an account, it is difficult to find the particular
account in the system of record without a human meaningful description.

This change addresses the need by
---------------------------------

- Require a description to be provided when creating an account through
an accounting adapter.
- Update the Xero adapter to concatenate the number and description to
create a unique name.

Next Steps
----------

- Update necessary business logic.