### PR TITLE
Fix: Adapter Behaviour

### DIFF
--- a/lib/accounting/adapter.ex
+++ b/lib/accounting/adapter.ex
@@ -1,7 +1,7 @@
 defmodule Accounting.Adapter do
   @callback start_link() :: Supervisor.on_start
   @callback register_categories([atom], timeout) :: :ok | {:error, any}
-  @callback create_account(String.t, timeout) :: :ok | {:error, any}
+  @callback create_account(String.t, String.t, timeout) :: :ok | {:error, any}
   @callback receive_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
   @callback spend_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
   @callback fetch_account_transactions(String.t, timeout) :: {:ok, [Accounting.AccountTransaction.t]} | {:error, any}


### PR DESCRIPTION
Why
---

The adapter `create_account` now has an arity of 3.

How
---

Update `Accounting.Adapter` behaviour.