### PR TITLE
Feature: Rate-limit error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v0.4.1 (2017-04-25)
+
+### 1. Enhancements
+
+  * [XeroAdapter] Return `:rate_limit_exceeded` errors

--- a/mix.exs
+++ b/mix.exs
@@ -9,14 +9,14 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.4.0",
+      version: "0.4.1",
       start_permanent: Mix.env === :prod,
     ]
   end
 
   defp deps do
     [
-      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:httpoison, "~> 0.9"},
       {:oauther, "~> 1.1.0"},
       {:poison, "~> 2.2 or ~> 3.0"},


### PR DESCRIPTION
Why
---

I want to receive a specific rate-limit error as opposed to an HTTP error so that I can handle this specific case.

How
---

* Transform rate-limit HTTP errors into `:rate_limit_exceeded` errors in Xero adapter.
* Add typespec.