### PR TITLE
Enhancement: Limit Xero API fetch frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.2 (2012-04-26)
+
+### 1. Enhancements
+
+  * [XeroAdapter] Fetch new transactions, at most, once per second
+
 ## v0.4.1 (2017-04-25)
 
 ### 1. Enhancements

--- a/lib/accounting.ex
+++ b/lib/accounting.ex
@@ -8,20 +8,20 @@ defmodule Accounting do
 
   @default_timeout 5_000
 
-  @spec register_categories([atom], timeout) :: :ok | {:error, any}
+  @spec register_categories([atom], timeout) :: :ok | {:error, term}
   def register_categories(categories, timeout \\ @default_timeout) do
     adapter().register_categories(categories, timeout)
   end
 
-  @spec create_account(String.t, String.t, timeout) :: :ok | {:error, any}
+  @spec create_account(String.t, String.t, timeout) :: :ok | {:error, term}
   def create_account(number, description, timeout \\ @default_timeout), do: adapter().create_account(number, description, timeout)
 
-  @spec receive_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
+  @spec receive_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, term}
   def receive_money(from, date, line_items, timeout \\ @default_timeout) do
     adapter().receive_money(from, date, filter_line_items(line_items), timeout)
   end
 
-  @spec spend_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
+  @spec spend_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, term}
   def spend_money(to, date, line_items, timeout \\ @default_timeout) do
     adapter().spend_money(to, date, filter_line_items(line_items), timeout)
   end
@@ -31,19 +31,19 @@ defmodule Accounting do
     for i <- line_items, i.amount !== 0, do: i
   end
 
-  @spec fetch_account_transactions(String.t, timeout) :: {:ok, [Accounting.AccountTransaction.t]} | {:error, any}
+  @spec fetch_account_transactions(String.t, timeout) :: {:ok, [Accounting.AccountTransaction.t]} | {:error, term}
   def fetch_account_transactions(account_number, timeout \\ @default_timeout) do
     response = adapter().fetch_account_transactions(account_number, timeout)
     with {:ok, txns} <- response, do: {:ok, sort_transactions(txns)}
   end
 
-  @spec fetch_balance(String.t, timeout) :: {:ok, integer} | {:error, any}
+  @spec fetch_balance(String.t, timeout) :: {:ok, integer} | {:error, term}
   def fetch_balance(account_number, timeout \\ @default_timeout) do
     response = adapter().fetch_account_transactions(account_number, timeout)
     with {:ok, txns} <- response, do: {:ok, calculate_balance(txns)}
   end
 
-  @spec fetch_balance_on_date(String.t, Date.t, timeout) :: {:ok, integer} | {:error, any}
+  @spec fetch_balance_on_date(String.t, Date.t, timeout) :: {:ok, integer} | {:error, term}
   def fetch_balance_on_date(account_number, date, timeout \\ @default_timeout) do
     response = fetch_account_transactions(account_number, timeout)
     with {:ok, transactions} <- response do
@@ -51,7 +51,7 @@ defmodule Accounting do
     end
   end
 
-  @spec fetch_ADB(String.t, Date.t, Date.t, timeout) :: {:ok, integer} | {:error, any}
+  @spec fetch_ADB(String.t, Date.t, Date.t, timeout) :: {:ok, integer} | {:error, term}
   def fetch_ADB(account_number, start_date, end_date, timeout \\ @default_timeout) do
     response = fetch_account_transactions(account_number, timeout)
     with {:ok, transactions} <- response do

--- a/lib/accounting/adapter.ex
+++ b/lib/accounting/adapter.ex
@@ -1,8 +1,8 @@
 defmodule Accounting.Adapter do
   @callback start_link() :: Supervisor.on_start
-  @callback register_categories([atom], timeout) :: :ok | {:error, any}
-  @callback create_account(String.t, String.t, timeout) :: :ok | {:error, any}
-  @callback receive_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
-  @callback spend_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, any}
-  @callback fetch_account_transactions(String.t, timeout) :: {:ok, [Accounting.AccountTransaction.t]} | {:error, any}
+  @callback register_categories([atom], timeout) :: :ok | {:error, term}
+  @callback create_account(String.t, String.t, timeout) :: :ok | {:error, term}
+  @callback receive_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, term}
+  @callback spend_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, term}
+  @callback fetch_account_transactions(String.t, timeout) :: {:ok, [Accounting.AccountTransaction.t]} | {:error, term}
 end

--- a/lib/accounting/structs/account_transaction.ex
+++ b/lib/accounting/structs/account_transaction.ex
@@ -1,5 +1,5 @@
 defmodule Accounting.AccountTransaction do
-  @type t :: %Accounting.AccountTransaction{}
+  @type t :: %__MODULE__{}
 
   defstruct [:amount, :description, :date]
 end

--- a/lib/accounting/structs/line_item.ex
+++ b/lib/accounting/structs/line_item.ex
@@ -1,5 +1,5 @@
 defmodule Accounting.LineItem do
-  @type t :: %Accounting.LineItem{}
+  @type t :: %__MODULE__{}
 
   defstruct [:description, :amount, :account_number, category: :other]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -9,13 +9,14 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.4.1",
+      version: "0.4.2",
       start_permanent: Mix.env === :prod,
     ]
   end
 
   defp deps do
     [
+      {:dialyxir, "~> 0.5", only: :dev, runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:httpoison, "~> 0.9"},
       {:oauther, "~> 1.1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
+  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], []},
   "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "hackney": {:hex, :hackney, "1.6.5", "8c025ee397ac94a184b0743c73b33b96465e85f90a02e210e86df6cbafaa5065", [:rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},

--- a/test/accounting/helpers_test.exs
+++ b/test/accounting/helpers_test.exs
@@ -2,8 +2,6 @@ defmodule Accounting.HelpersTest do
   use ExUnit.Case, async: true
   doctest Accounting.Helpers
 
-  Application.put_env(:accounting, :adapter, Accounting.TestAdapter)
-
   alias Accounting.{AccountTransaction, Helpers}
 
   describe "calculate_balance/1" do


### PR DESCRIPTION
Why
---

Xero rate-limits API calls to 60 per minute.

How
---

Fetch new transactions, at most, once per second.

Also
----

Add and improve typespecs.