### PR TITLE
Chore: Update CircleCI config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,9 +6,9 @@ dependencies:
   cache_directories:
     - ~/.asdf
   pre:
-    - if ! asdf | grep version; then git clone https://github.com/HashNuke/asdf.git ~/.asdf; fi
-    - if ! asdf list erlang; then asdf plugin-add erlang https://github.com/HashNuke/asdf-erlang.git; fi
-    - if ! asdf list elixir; then asdf plugin-add elixir https://github.com/HashNuke/asdf-elixir.git; fi
+    - if ! asdf | grep version; then git clone https://github.com/asdf-vm/asdf.git ~/.asdf; fi
+    - if ! asdf list erlang; then asdf plugin-add erlang https://github.com/asdf-vm/asdf-erlang.git; fi
+    - if ! asdf list elixir; then asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git; fi
     - erlang_version=$(awk '/erlang/ { print $2 }' .tool-versions) && asdf install erlang ${erlang_version}
     - elixir_version=$(awk '/elixir/ { print $2 }' .tool-versions) && asdf install elixir ${elixir_version}
     - mix local.hex --force


### PR DESCRIPTION
Why
---

GitHub repos for asdf were transferred from HashNuke to asdf-vm.

How
---

Replace `HashNuke` in `circle.yml` with `asdf-vm`.