### PR TITLE
Simplify API

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.4.1
-erlang 19.2
+elixir 1.4.5
+erlang 20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v0.6.0 (2017-06-27)
+
+### 1. Enhancements
+
+  * Add `transact/4`
+  * [Assertions] Add `assert_transaction_with_line_item/3`
+  * [Assertions] Add `refute_transaction_with_line_item/3`
+
+### 2. Deprecations
+
+  * `receive_money/4`, in favor of `transact/4`
+  * `spend_money/4`
+  * [Assertions] `assert_received_money_with_line_item/3`, in favor of
+    `assert_transaction_with_line_item/3`
+  * [Assertions] `refute_received_money_with_line_item/2`, in favor of
+    `refute_transaction_with_line_item/2`
+  * [Assertions] `assert_spent_money_with_line_item/3`
+  * [Assertions] `refute_spent_money_with_line_item/2`
+
+
 ## v0.5.0 (2017-04-27)
 
 Accounting no longer starts its adapter processes automatically. You can now

--- a/lib/accounting.ex
+++ b/lib/accounting.ex
@@ -55,19 +55,14 @@ defmodule Accounting do
     end
   end
 
-  @spec receive_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, term}
-  def receive_money(from, date, line_items, timeout \\ @default_timeout) do
-    adapter().receive_money(from, date, filter_line_items(line_items), timeout)
-  end
-
   @spec register_categories([atom], timeout) :: :ok | {:error, term}
   def register_categories(categories, timeout \\ @default_timeout) do
     adapter().register_categories(categories, timeout)
   end
 
-  @spec spend_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, term}
-  def spend_money(to, date, line_items, timeout \\ @default_timeout) do
-    adapter().spend_money(to, date, filter_line_items(line_items), timeout)
+  @spec transact(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, term}
+  def transact(party, date, line_items, timeout \\ @default_timeout) do
+    adapter().transact(party, date, filter_line_items(line_items), timeout)
   end
 
   @spec filter_line_items([Accounting.LineItem.t]) :: [Accounting.LineItem.t]

--- a/lib/accounting/adapter.ex
+++ b/lib/accounting/adapter.ex
@@ -1,8 +1,7 @@
 defmodule Accounting.Adapter do
   @callback create_account(String.t, String.t, timeout) :: :ok | {:error, term}
   @callback fetch_account_transactions(String.t, timeout) :: {:ok, [Accounting.AccountTransaction.t]} | {:error, term}
-  @callback receive_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, term}
   @callback register_categories([atom], timeout) :: :ok | {:error, term}
-  @callback spend_money(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, term}
   @callback start_link(opts :: any) :: Supervisor.on_start
+  @callback transact(String.t, Date.t, [Accounting.LineItem.t], timeout) :: :ok | {:error, term}
 end

--- a/lib/accounting/assertions.ex
+++ b/lib/accounting/assertions.ex
@@ -23,49 +23,25 @@ defmodule Accounting.Assertions do
     end
   end
 
-  @spec assert_received_money_with_line_item(String.t, Date.t, [Accounting.LineItem.t]) :: true | no_return
-  def assert_received_money_with_line_item(from, date, line_item) do
+  @spec assert_transaction_with_line_item(String.t, Date.t, [Accounting.LineItem.t]) :: true | no_return
+  def assert_transaction_with_line_item(party, date, line_item) do
     receive do
-      {:received_money, ^from, ^date, ^line_item} -> true
+      {:transaction, ^party, ^date, ^line_item} -> true
     after
       @timeout ->
         flunk """
-        Money was not received from '#{from}' on #{date} with the line item:
+        Transaction did not occur with '#{party}' on #{date} with the line item:
 
         #{inspect line_item}
         """
     end
   end
 
-  @spec refute_received_money(String.t, Date.t) :: true | no_return
-  def refute_received_money(from, date) do
+  @spec refute_transaction(String.t, Date.t) :: true | no_return
+  def refute_transaction(from, date) do
     receive do
-      {:received_money, ^from, ^date, _} ->
-        flunk "Money was unexpectedly received."
-    after
-      @timeout -> true
-    end
-  end
-
-  @spec assert_spent_money_with_line_item(String.t, Date.t, [Accounting.LineItem.t]) :: true | no_return
-  def assert_spent_money_with_line_item(to, date, line_item) do
-    receive do
-      {:spent_money, ^to, ^date, ^line_item} -> true
-    after
-      @timeout ->
-        flunk """
-        Money was not spent towards '#{to}' on #{date} with the line item:
-
-        #{inspect line_item}
-        """
-    end
-  end
-
-  @spec refute_spent_money(String.t, Date.t) :: true | no_return
-  def refute_spent_money(to, date) do
-    receive do
-      {:spent_money, ^to, ^date, _} ->
-        flunk "Money was unexpectedly spent."
+      {:transaction, ^from, ^date, _} ->
+        flunk "Unexepcted transaction occurred."
     after
       @timeout -> true
     end

--- a/lib/accounting/views/xero_view.ex
+++ b/lib/accounting/views/xero_view.ex
@@ -27,12 +27,12 @@ defmodule Accounting.XeroView do
     </Option>
     """
   end
-  def render("receive_money.xml", assigns) do
+  def render("credit.xml", assigns) do
     """
     <BankTransactions>
       <BankTransaction>
         <Type>RECEIVE</Type>
-        <Contact><Name>#{xml_escape assigns[:from]}</Name></Contact>
+        <Contact><Name>#{xml_escape assigns[:party]}</Name></Contact>
         <Date>#{assigns[:date]}</Date>
         <LineItems>
           #{for line_item <- assigns[:line_items] do
@@ -46,12 +46,12 @@ defmodule Accounting.XeroView do
     </BankTransactions>
     """
   end
-  def render("spend_money.xml", assigns) do
+  def render("debit.xml", assigns) do
     """
     <BankTransactions>
       <BankTransaction>
         <Type>SPEND</Type>
-        <Contact><Name>#{xml_escape assigns[:to]}</Name></Contact>
+        <Contact><Name>#{xml_escape assigns[:party]}</Name></Contact>
         <Date>#{assigns[:date]}</Date>
         <LineItems>
           #{for line_item <- assigns[:line_items] do
@@ -71,7 +71,7 @@ defmodule Accounting.XeroView do
       <Invoice>
         <Type>ACCREC</Type>
         <Status>AUTHORISED</Status>
-        <Contact><Name>#{xml_escape assigns[:from]}</Name></Contact>
+        <Contact><Name>#{xml_escape assigns[:party]}</Name></Contact>
         <Date>#{assigns[:date]}</Date>
         <DueDate>#{assigns[:date]}</DueDate>
         <LineAmountTypes>NoTax</LineAmountTypes>

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Accounting.Mixfile do
       description: "Accounting.",
       elixir: "~> 1.4",
       package: package(),
-      version: "0.5.0",
+      version: "0.6.0",
       start_permanent: Mix.env === :prod,
     ]
   end


### PR DESCRIPTION
Why
---

The total of the line items determines whether determines whether a transaction is considered a net debit, net credit, or net transfer.

The previous API allowed the user to submit negative debits and negative credits, which was overly-complex and resulted in failure.

How
---

* Remove `spend_money/4`
* Rename `receive_money/4` to `transact/4`
* Enable XeroAdapter to send correct API call based on line item total
* Clean up assertions
* Update Elixir to 1.4.5 and Erlang to 20.0 in `.tool-versions`

Side effects
------------

* Breaking API changes