### PR TITLE
Fix: Xero Adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.7.1 (2017-08-24)
+
+### 1. Enhancements
+
+  * Add new types
+
+### 2. Bug fixes
+
+  * [XeroAdapter] Return accounts from `fetch_accounts/2` for accounts that have
+    not been registered
+
 ## v0.7.0 (2017-08-21)
 
 This release radically alters the API. It serves to separate value functions

--- a/lib/accounting.ex
+++ b/lib/accounting.ex
@@ -1,0 +1,3 @@
+defmodule Accounting do
+  @type account_number :: String.t
+end

--- a/lib/accounting/account.ex
+++ b/lib/accounting/account.ex
@@ -5,14 +5,14 @@ defmodule Accounting.Account do
 
   alias Accounting.AccountTransaction
 
-  @type no :: String.t
+  @opaque t :: %__MODULE__{number: account_number, transactions: [AccountTransaction.t]}
 
-  @opaque t :: %__MODULE__{number: no, transactions: [AccountTransaction.t]}
+  @typep account_number :: Accounting.account_number
 
   defstruct [:number, {:transactions, []}]
 
   @spec average_daily_balance(t, Date.Range.t) :: integer
-  def average_daily_balance(account, date_range) do
+  def average_daily_balance(%__MODULE__{} = account, %Date.Range{} = date_range) do
     account
     |> Map.fetch!(:transactions)
     |> daily_balances(date_range)
@@ -51,12 +51,12 @@ defmodule Accounting.Account do
   defp mean(list), do: Enum.reduce(list, 0, &Kernel.+/2) / length(list)
 
   @spec balance(t) :: integer
-  def balance(account) do
+  def balance(%__MODULE__{} = account) do
     Enum.reduce(account.transactions, 0, & &1.amount + &2)
   end
 
   @spec balance_on_date(t, Date.t) :: integer
-  def balance_on_date(account, date) do
+  def balance_on_date(%__MODULE__{} = account, %Date{} = date) do
     {_, balance} =
       Enumerable.reduce account.transactions, {:cont, 0}, fn transaction, acc ->
         if Date.compare(transaction.date, date) === :gt do
@@ -70,7 +70,7 @@ defmodule Accounting.Account do
   end
 
   @spec transactions(t) :: [AccountTransaction.t]
-  def transactions(account), do: account.transactions
+  def transactions(%__MODULE__{} = account), do: account.transactions
 
   defimpl Inspect do
     import Inspect.Algebra, only: [concat: 1]

--- a/lib/accounting/adapter.ex
+++ b/lib/accounting/adapter.ex
@@ -1,10 +1,12 @@
 defmodule Accounting.Adapter do
-  alias Accounting.{Account, LineItem}
+  alias Accounting.{Journal, LineItem}
+
+  @typep account_number :: Accounting.account_number
 
   @callback child_spec(keyword) :: Supervisor.Spec.spec
-  @callback fetch_accounts([Account.no], timeout) :: {:ok, %{optional(Account.no) => Account.t}} | {:error, term}
+  @callback fetch_accounts([account_number], timeout) :: {:ok, Journal.accounts} | {:error, term}
   @callback record_entry(String.t, Date.t, [LineItem.t], timeout) :: :ok | {:error, term}
-  @callback register_account(Account.no, String.t, timeout) :: :ok | {:error, term}
+  @callback register_account(account_number, String.t, timeout) :: :ok | {:error, term}
   @callback register_categories([atom], timeout) :: :ok | {:error, term}
   @callback start_link(opts :: any) :: Supervisor.on_start
 end

--- a/lib/accounting/adapters/test_adapter.ex
+++ b/lib/accounting/adapters/test_adapter.ex
@@ -1,10 +1,11 @@
 defmodule Accounting.TestAdapter do
-  alias Accounting.{Account, AccountTransaction, Adapter, Helpers}
+  alias Accounting.{Account, AccountTransaction, Adapter, Helpers, Journal}
   import Helpers, only: [sort_transactions: 1]
 
   @behaviour Adapter
 
-  @typep transactions :: %{optional(String.t) => [AccountTransaction.t]}
+  @typep account_number :: Accounting.account_number
+  @typep transactions :: %{optional(account_number) => [AccountTransaction.t]}
 
   @impl Adapter
   def child_spec(opts), do: Supervisor.Spec.worker(__MODULE__, [opts])
@@ -14,7 +15,7 @@ defmodule Accounting.TestAdapter do
     {:ok, Agent.get(__MODULE__, &get_accounts(&1, numbers))}
   end
 
-  @spec get_accounts(transactions, [Account.no]) :: %{optional(Account.no) => Account.t}
+  @spec get_accounts(transactions, [account_number]) :: Journal.accounts
   defp get_accounts(transactions, numbers) do
     for number <- numbers, into: %{} do
       account =
@@ -49,7 +50,7 @@ defmodule Accounting.TestAdapter do
     end
   end
 
-  @spec all_exist?([String.t]) :: boolean
+  @spec all_exist?([account_number]) :: boolean
   defp all_exist?(account_numbers) do
     Agent.get __MODULE__, fn state ->
       Enum.all?(account_numbers, &Map.has_key?(state, &1))
@@ -67,7 +68,7 @@ defmodule Accounting.TestAdapter do
     end
   end
 
-  @spec exists?(String.t) :: boolean
+  @spec exists?(account_number) :: boolean
   defp exists?(account_number) do
     Agent.get(__MODULE__, &Map.has_key?(&1, account_number))
   end

--- a/lib/accounting/journal.ex
+++ b/lib/accounting/journal.ex
@@ -5,12 +5,16 @@ defmodule Accounting.Journal do
 
   alias Accounting.{Account, LineItem}
 
+  @type accounts :: %{optional(account_number) => Account.t}
+
+  @typep account_number :: Accounting.account_number
+
   @default_timeout 5_000
 
   @spec child_spec(keyword) :: Supervisor.Spec.spec
   def child_spec(opts), do: Supervisor.Spec.worker(__MODULE__, [opts])
 
-  @spec fetch_accounts([Account.no], timeout) :: {:ok, %{optional(Account.no) => Account.t}} | {:error, term}
+  @spec fetch_accounts([account_number], timeout) :: {:ok, accounts} | {:error, term}
   def fetch_accounts(numbers, timeout \\ @default_timeout) do
     adapter().fetch_accounts(numbers, timeout)
   end
@@ -21,7 +25,7 @@ defmodule Accounting.Journal do
     adapter().record_entry(party, date, filtered_line_items, timeout)
   end
 
-  @spec register_account(Account.no, String.t, timeout) :: :ok | {:error, term}
+  @spec register_account(account_number, String.t, timeout) :: :ok | {:error, term}
   def register_account(number, description, timeout \\ @default_timeout) do
     adapter().register_account(number, description, timeout)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Accounting.Mixfile do
       ],
       elixir: "~> 1.5",
       package: package(),
-      version: "0.7.0",
+      version: "0.7.1",
       start_permanent: Mix.env === :prod,
     ]
   end

--- a/test/accounting/adapter/test_adapter_test.exs
+++ b/test/accounting/adapter/test_adapter_test.exs
@@ -2,7 +2,7 @@ defmodule Accounting.TestAdapterTest do
   use ExUnit.Case, async: true
   doctest Accounting.TestAdapter
 
-  alias Accounting.{Account, AccountTransaction, LineItem, TestAdapter}
+  alias Accounting.{Account, LineItem, TestAdapter}
 
   setup do
     {:ok, _} = TestAdapter.start_link([])


### PR DESCRIPTION
Why
---

If one tried to fetch accounts for accounts that weren’t registered, the account values would be empty lists instead of accounts without transactions

How
---

Return accounts from `fetch_accounts/2` for accounts that have not been registered