### PR TITLE
Update assertions to match latest API.

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -25,7 +25,7 @@
         {Credo.Check.Design.TagFIXME},
 
         {Credo.Check.Readability.FunctionNames},
-        {Credo.Check.Readability.LargeNumbers},
+        {Credo.Check.Readability.LargeNumbers, false},
         {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.10.0 (2017-12-13)
+
+### 1. Enhancements
+
+  * [Assertions] Add `assert_registered_categories/2`
+  * [Assertions] Add `assert_recorded_entries/2`
+
+### 2. Removals
+
+  * [Assertions] `assert_registered_category/2`, in favor of `assert_registered_categories/2`
+  * [Assertions] `assert_transaction_with_line_item/4`, in favor of `assert_recorded_entries/2`
+
 ## v0.9.0 (2017-12-11)
 
 ### 1. Enhancements

--- a/circle.yml
+++ b/circle.yml
@@ -17,4 +17,6 @@ dependencies:
     - mix deps.compile
 test:
   override:
+    - mix do clean, compile --warnings-as-errors
     - mix test
+    - mix credo

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Accounting.Mixfile do
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       package: package(),
-      version: "0.9.0",
+      version: "0.10.0",
       start_permanent: Mix.env === :prod,
     ]
   end

--- a/test/accounting/adapter/test_adapter_test.exs
+++ b/test/accounting/adapter/test_adapter_test.exs
@@ -99,9 +99,7 @@ defmodule Accounting.TestAdapterTest do
       assert {:error, :no_such_account} ===
         TestAdapter.record_entries(journal_id, [entry], :infinity)
 
-      for i <- items do
-        assert_received {:transaction, ^journal_id, ^party, ^date, ^i}
-      end
+      assert_received {:recorded_entries, ^journal_id, [^entry]}
 
       assert {:ok, %{^number => account}} =
         TestAdapter.fetch_accounts(journal_id, [number], :infinity)
@@ -126,7 +124,7 @@ defmodule Accounting.TestAdapterTest do
       assert :ok ===
         TestAdapter.record_entries(journal_id, [entry], :infinity)
 
-      assert_received {:transaction, ^journal_id, ^party, ^date, ^item}
+      assert_received {:recorded_entries, ^journal_id, [^entry]}
 
       assert {:ok, %{^number => account}} =
         TestAdapter.fetch_accounts(journal_id, [number], :infinity)
@@ -159,13 +157,14 @@ defmodule Accounting.TestAdapterTest do
         amount: amount2,
         description: desc2,
       }
-      entry1 = Entry.new(party1, date1, [item1])
-      entry2 = Entry.new(party2, date2, [item2])
+      entries = [
+        Entry.new(party1, date1, [item1]),
+        Entry.new(party2, date2, [item2]),
+      ]
       assert :ok ===
-        TestAdapter.record_entries(journal_id, [entry1, entry2], :infinity)
+        TestAdapter.record_entries(journal_id, entries, :infinity)
 
-      assert_received {:transaction, ^journal_id, ^party1, ^date1, ^item1}
-      assert_received {:transaction, ^journal_id, ^party2, ^date2, ^item2}
+      assert_received {:recorded_entries, ^journal_id, ^entries}
 
       assert {:ok, %{^number1 => account1, ^number2 => account2}} =
         TestAdapter.fetch_accounts(journal_id, [number1, number2], :infinity)
@@ -193,7 +192,7 @@ defmodule Accounting.TestAdapterTest do
       assert {:error, :duplicate} ===
         TestAdapter.register_account(journal_id, number, name, :infinity)
 
-      assert_received {:created_account, ^journal_id, ^number}
+      assert_received {:registered_account, ^journal_id, ^number}
     end
 
     test "with a new account", %{name: name, number: number} do
@@ -201,7 +200,7 @@ defmodule Accounting.TestAdapterTest do
       assert :ok ===
         TestAdapter.register_account(journal_id, number, name, :infinity)
 
-      assert_received {:created_account, ^journal_id, ^number}
+      assert_received {:registered_account, ^journal_id, ^number}
     end
   end
 
@@ -211,9 +210,7 @@ defmodule Accounting.TestAdapterTest do
     assert :ok ===
       TestAdapter.register_categories(journal_id, categories, :infinity)
 
-    for c <- categories do
-      assert_received {:registered_category, ^journal_id, ^c}
-    end
+    assert_received {:registered_categories, ^journal_id, ^categories}
   end
 
   test "reset/0" do


### PR DESCRIPTION
* The assertions drifted from the adapter functions.

* Update circle.yml to fail on compilation warnings.
* Update circle.yml to use credo.
* Update credo config to not check LargeNumbers.
* [Assertions] Add `assert_registered_categories/2`
* [Assertions] Add `assert_recorded_entries/2`

  * [Assertions] `assert_registered_category/2`, in favor of `assert_registered_categories/2`
  * [Assertions] `assert_transaction_with_line_item/4`, in favor of `assert_recorded_entries/2`