### PR TITLE
Fix tests.

### DIFF
--- a/test/accounting/adapter/test_adapter_test.exs
+++ b/test/accounting/adapter/test_adapter_test.exs
@@ -1,5 +1,5 @@
 defmodule Accounting.TestAdapterTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   doctest Accounting.TestAdapter
 
   alias Accounting.{Account, Entry, LineItem, TestAdapter}


### PR DESCRIPTION
Why:

* The TestAdapterTest is not able to be ran asynchronously due to the
  TestAdapter being a named process which means that there can't be more
  than one running at a time.

This change addresses the need by:

* Update TestAdapterTest to not run asynchronously due to our individual
  test isolation requirements for the TestAdapter's Agent state.