### PR TITLE
Add line_items to Entry inspect output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### 1. Enhancements
+
+  * [Entry] Update Inspect implementation to output line_items.
+
 ## v0.10.0 (2017-12-13)
 
 ### 1. Enhancements

--- a/lib/accounting/entry.ex
+++ b/lib/accounting/entry.ex
@@ -25,20 +25,4 @@ defmodule Accounting.Entry do
       total: total,
     }
   end
-
-  defimpl Inspect do
-    def inspect(entry, opts) do
-      docs = [
-        "#Entry<party: ",
-        entry.party,
-        ", date: ",
-        Inspect.Algebra.to_doc(entry.date, opts),
-        ", total: ",
-        Inspect.Algebra.to_doc(entry.total, opts),
-        ">",
-      ]
-
-      Inspect.Algebra.concat(docs)
-    end
-  end
 end

--- a/test/accounting/entry_test.exs
+++ b/test/accounting/entry_test.exs
@@ -18,15 +18,4 @@ defmodule Accounting.EntryTest do
     assert line_items === entry.line_items
     assert 5 === entry.total
   end
-
-  test "Inspect implementation" do
-    party = "ah yeah williams"
-    date = ~D[1934-10-10]
-    line_items = [
-      %LineItem{account_number: "n", amount: 3, description: "three"},
-      %LineItem{account_number: "n", amount: 4, description: "four"},
-    ]
-    assert "#Entry<party: #{party}, date: ~D[1934-10-10], total: 7>" ===
-      inspect(Entry.new(party, date, line_items))
-  end
 end


### PR DESCRIPTION
Why:

* It was tedious to not get the line_items when inspecting an Entry.

This change addresses the need by:

* Delete the Inspect implementation in Entry so that all struct fields
  show when inspected.
* Remove the Entry inspect test.