### PR TITLE
Add `refute_registered_categories/2`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Unreleased
+## v0.10.1 (2017-12-15)
 
 ### 1. Enhancements
 
+  * [Assertions] Add `refute_registered_categories/2`
   * [Entry] Update Inspect implementation to output line_items.
 
 ## v0.10.0 (2017-12-13)

--- a/lib/accounting/assertions.ex
+++ b/lib/accounting/assertions.ex
@@ -22,6 +22,20 @@ defmodule Accounting.Assertions do
     end
   end
 
+  @spec refute_registered_categories(Journal.id, [String.t]) :: true | no_return
+  def refute_registered_categories(journal_id, categories) do
+    receive do
+      {:registered_categories, ^journal_id, ^categories} ->
+        flunk """
+        Unexpected categories were registered:
+
+        #{inspect categories}
+        """
+    after
+      @timeout -> true
+    end
+  end
+
   @spec assert_created_account(Journal.id, String.t) :: true | no_return
   def assert_created_account(journal_id, number) do
     receive do

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Accounting.Mixfile do
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       package: package(),
-      version: "0.10.0",
+      version: "0.10.1",
       start_permanent: Mix.env === :prod,
     ]
   end


### PR DESCRIPTION
Why:

* I came across the need to ensure that categories weren't registered.

This change addresses the need by:

* Implement `refute_registered_categories/2`
* Update version so we can release a new version.

Side effects:

* This release should be non breaking.