### PR TITLE
Add `list_accounts/2`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.10.2 (2017-12-19)
+
+### 1. Enhancements
+
+  * [Journal] Add `list_accounts/2`
+
 ## v0.10.1 (2017-12-15)
 
 ### 1. Enhancements

--- a/lib/accounting/adapter.ex
+++ b/lib/accounting/adapter.ex
@@ -8,6 +8,7 @@ defmodule Accounting.Adapter do
   @typep account_number :: Accounting.account_number
 
   @callback child_spec(keyword) :: Supervisor.child_spec
+  @callback list_accounts(Journal.id, timeout) :: {:ok, [account_number]} | {:error, term}
   @callback fetch_accounts(Journal.id, [account_number], timeout) :: {:ok, Journal.accounts} | {:error, term}
   @callback record_entries(Journal.id, [Entry.t, ...], timeout) :: :ok | {:error, [Entry.Error.t] | term}
   @callback register_account(Journal.id, account_number, String.t, timeout) :: :ok | {:error, term}

--- a/lib/accounting/adapters/test_adapter.ex
+++ b/lib/accounting/adapters/test_adapter.ex
@@ -25,6 +25,17 @@ defmodule Accounting.TestAdapter do
   end
 
   @impl Adapter
+  def list_accounts(journal_id, _timeout) do
+    accounts = Agent.get(__MODULE__, fn(state) ->
+      state
+      |> Map.get(journal_id, %{})
+      |> Map.keys()
+    end)
+
+    {:ok, accounts}
+  end
+
+  @impl Adapter
   def fetch_accounts(journal_id, numbers, _timeout) do
     {:ok, Agent.get(__MODULE__, &get_accounts(&1, journal_id, numbers))}
   end

--- a/lib/accounting/adapters/xero_adapter.ex
+++ b/lib/accounting/adapters/xero_adapter.ex
@@ -273,6 +273,19 @@ defmodule Accounting.XeroAdapter do
   end
 
   @impl Adapter
+  def list_accounts(journal_id, timeout) do
+    creds = creds(journal_id)
+    with {:ok, resp} <- http_client().get("Accounts", timeout, creds) do
+      resp.body
+      |> Poison.decode!
+      |> Map.fetch!("Accounts")
+      |> Stream.map(&(Map.get(&1, "Code")))
+      |> Enum.filter(&(&1))
+      |> (&({:ok, &1})).()
+    end
+  end
+
+  @impl Adapter
   def fetch_accounts(journal_id, numbers, timeout) when is_list(numbers) do
     memo = Agent.get(__MODULE__, & &1.memo, timeout)
     Agent.get_and_update memo, fn %{^journal_id => journal_memo} = state ->

--- a/lib/accounting/journal.ex
+++ b/lib/accounting/journal.ex
@@ -17,6 +17,11 @@ defmodule Accounting.Journal do
     %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}}
   end
 
+  @spec list_accounts(Journal.id, timeout) :: {:ok, [account_number]} | {:error, term}
+  def list_accounts(journal_id, timeout \\ @default_timeout) do
+    adapter().list_accounts(journal_id, timeout)
+  end
+
   @spec fetch_accounts(Journal.id, [account_number], timeout) :: {:ok, accounts} | {:error, term}
   def fetch_accounts(journal_id, numbers, timeout \\ @default_timeout) do
     adapter().fetch_accounts(journal_id, numbers, timeout)

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Accounting.Mixfile do
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       package: package(),
-      version: "0.10.1",
+      version: "0.10.2",
       start_permanent: Mix.env === :prod,
     ]
   end

--- a/test/accounting/adapter/test_adapter_test.exs
+++ b/test/accounting/adapter/test_adapter_test.exs
@@ -9,6 +9,20 @@ defmodule Accounting.TestAdapterTest do
     :ok
   end
 
+  describe "list_accounts/2" do
+    test "without any registered accounts" do
+      assert {:ok, []} === TestAdapter.list_accounts(:blue_journal, :infinity)
+    end
+
+    test "with a registered account" do
+      journal_id = :black_journal
+      number = "F1234"
+      :ok = TestAdapter.register_account(journal_id, number, nil, :infinity)
+
+      assert {:ok, [number]} === TestAdapter.list_accounts(journal_id, :infinity)
+    end
+  end
+
   describe "fetch_accounts/2" do
     setup do: %{number: "F100"}
 

--- a/test/accounting/adapter/xero_adapter_test.exs
+++ b/test/accounting/adapter/xero_adapter_test.exs
@@ -35,6 +35,20 @@ defmodule Accounting.XeroAdapterTest do
     }
   end
 
+  describe "list_accounts/2" do
+    test "returns HTTPoison errors", %{creds: creds, journal_id: journal_id} do
+      assert {:error, %HTTPoison.Error{reason: HTTPoison.SuperError}} ===
+        XeroAdapter.list_accounts(journal_id, 1)
+
+      assert_received {:http_get, "Accounts", 1, ^creds, []}
+    end
+
+    test "returns a list of account numbers", %{journal_id: journal_id} do
+      assert {:ok, ["F1234", "G1234"]} ===
+        XeroAdapter.list_accounts(journal_id, :infinity)
+    end
+  end
+
   describe "record_entries/3" do
     test "returns HTTPoison errors", %{bank_id: bank_id, creds: creds, journal_id: journal_id, params: params} do
       item = %LineItem{account_number: "B42", amount: 4_99, description: "Soap"}

--- a/test/support/stub_xero_adapter_http_client.ex
+++ b/test/support/stub_xero_adapter_http_client.ex
@@ -18,8 +18,18 @@ defmodule StubXeroAdapterHTTPClient do
     body = Poison.encode!(value)
     {:ok, %HTTPoison.Response{status_code: 200, headers: [], body: body}}
   end
+  def get(endpoint, 1 = timeout, credentials, params) do
+    send self(), {:http_get, endpoint, timeout, credentials, params}
+    {:error, %HTTPoison.Error{reason: HTTPoison.SuperError}}
+  end
   def get("Journals", _, _, _) do
     body = Poison.encode!(%{"Journals" => []})
+    {:ok, %HTTPoison.Response{status_code: 200, headers: [], body: body}}
+  end
+  def get("Accounts", _, _, _) do
+    body = Poison.encode!(
+      %{"Accounts" => [%{"Code" => "F1234"}, %{"Code" => "G1234"}]}
+    )
     {:ok, %HTTPoison.Response{status_code: 200, headers: [], body: body}}
   end
   def get(endpoint, timeout, credentials, params) do


### PR DESCRIPTION
Why:

* Our app consuming this library requires us get back a list of accounts
  that exist in Xero.

This change addresses the need by:

* Add `Journal.list_accounts/2`