### PR TITLE
Add `refute_account_created/2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.10.3 (2017-12-19)
+
+### 1. Enhancements
+
+  * [Assertions] Add `refute_account_created/2`
+
 ## v0.10.2 (2017-12-19)
 
 ### 1. Enhancements

--- a/lib/accounting/assertions.ex
+++ b/lib/accounting/assertions.ex
@@ -46,6 +46,17 @@ defmodule Accounting.Assertions do
     end
   end
 
+  @spec refute_created_account(Journal.id, String.t) :: true | no_return
+  def refute_created_account(journal_id, number) do
+    receive do
+      {:registered_account, ^journal_id, ^number} ->
+        flunk "An account was unexpectedly created with the number '#{number}'."
+    after
+      @timeout ->
+        true
+    end
+  end
+
   @spec assert_recorded_entries(Journal.id, [Entry.t]) :: true | no_return
   def assert_recorded_entries(journal_id, entries) do
     receive do

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Accounting.Mixfile do
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       package: package(),
-      version: "0.10.2",
+      version: "0.10.3",
       start_permanent: Mix.env === :prod,
     ]
   end


### PR DESCRIPTION
Why:

* To allow testing that certain accounts were not created.

This change addresses the need by:

* Add `Assertions.refute_account_created/2`