### PR TITLE
v0.10.4: Add ability to setup Xero.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## V0.10.4 (2017-12-21)
+
+### 1. Enhancements
+
+  * [Assertions] Add `assert_setup_accounts/2`
+  * [Assertions] Add `refute_setup_accounts/2`
+  * [Assertions] Add `assert_setup_account_conversions/4`
+  * [Assertions] Add `refute_setup_account_conversions/4`
+  * [Account] Add `Account.setup` type.
+  * [Account] Add `:description` and `:conversion_balance` fields to struct.
+  * [Adapter] Add `setup_accounts/3` callback
+  * [Adapter] Add `setup_account_conversions/5` callback
+  * [Journal] Add `setup_accounts/2-3`
+  * [Journal] Add `setup_account_conversions/4-5`
+  * [XeroAdapter] Add `setup_accounts/3`
+  * [XeroAdapter] Add `setup_account_conversions/5`
+  * [XeroAdapter.HTTPClient] Add `post/4-5` callback
+  * [XeroAdapter.DefaultHTTPClient] Add `post/4-5` callback
+
 ## v0.10.3 (2017-12-19)
 
 ### 1. Enhancements

--- a/lib/accounting/account.ex
+++ b/lib/accounting/account.ex
@@ -5,11 +5,20 @@ defmodule Accounting.Account do
 
   alias Accounting.AccountTransaction
 
-  @opaque t :: %__MODULE__{number: account_number, transactions: [AccountTransaction.t]}
+  @type setup :: %__MODULE__{
+    number: account_number,
+    description: String.t,
+    conversion_balance: integer,
+  }
+
+  @opaque t :: %__MODULE__{
+    number: account_number,
+    transactions: [AccountTransaction.t]
+  }
 
   @typep account_number :: Accounting.account_number
 
-  defstruct [:number, {:transactions, []}]
+  defstruct [:number, :description, :conversion_balance, {:transactions, []}]
 
   @spec average_daily_balance(t, Date.Range.t) :: integer
   def average_daily_balance(%__MODULE__{} = account, %Date.Range{} = date_range) do

--- a/lib/accounting/adapter.ex
+++ b/lib/accounting/adapter.ex
@@ -8,6 +8,8 @@ defmodule Accounting.Adapter do
   @typep account_number :: Accounting.account_number
 
   @callback child_spec(keyword) :: Supervisor.child_spec
+  @callback setup_accounts(Journal.id, [Account.setup, ...], timeout) :: :ok | {:error, term}
+  @callback setup_account_conversions(Journal.id, 1..12, pos_integer, [Account.setup, ...], timeout) :: :ok | {:error, term}
   @callback list_accounts(Journal.id, timeout) :: {:ok, [account_number]} | {:error, term}
   @callback fetch_accounts(Journal.id, [account_number], timeout) :: {:ok, Journal.accounts} | {:error, term}
   @callback record_entries(Journal.id, [Entry.t, ...], timeout) :: :ok | {:error, [Entry.Error.t] | term}

--- a/lib/accounting/adapter.ex
+++ b/lib/accounting/adapter.ex
@@ -3,7 +3,7 @@ defmodule Accounting.Adapter do
   A behaviour module for implementing the adapter for a particular journal.
   """
 
-  alias Accounting.{Entry, Journal}
+  alias Accounting.{Account, Entry, Journal}
 
   @typep account_number :: Accounting.account_number
 

--- a/lib/accounting/adapters/test_adapter.ex
+++ b/lib/accounting/adapters/test_adapter.ex
@@ -25,6 +25,19 @@ defmodule Accounting.TestAdapter do
   end
 
   @impl Adapter
+  def setup_accounts(journal_id, accounts, _timeout) do
+    send self(), {:setup_accounts, journal_id, accounts}
+
+    Agent.update(__MODULE__, fn(state) ->
+      journal_state = Enum.reduce(accounts, %{}, fn(account, acc) ->
+        Map.put(acc, account.number, [])
+      end)
+
+      Map.put(state, journal_id, journal_state)
+    end)
+  end
+
+  @impl Adapter
   def list_accounts(journal_id, _timeout) do
     accounts = Agent.get(__MODULE__, fn(state) ->
       state
@@ -38,6 +51,17 @@ defmodule Accounting.TestAdapter do
   @impl Adapter
   def fetch_accounts(journal_id, numbers, _timeout) do
     {:ok, Agent.get(__MODULE__, &get_accounts(&1, journal_id, numbers))}
+  end
+
+  @impl Adapter
+  def register_account(journal_id, number, _description, _timeout) do
+    send self(), {:registered_account, journal_id, number}
+
+    if exists?(journal_id, number) do
+      {:error, :duplicate}
+    else
+      Agent.update(__MODULE__, &put_account(&1, journal_id, number))
+    end
   end
 
   @spec get_accounts(state, Journal.id, [account_number]) :: Journal.accounts
@@ -97,17 +121,6 @@ defmodule Accounting.TestAdapter do
   defp all_exist?(journal_id, account_numbers) do
     Agent.get __MODULE__, fn state ->
       Enum.all?(account_numbers, &Map.has_key?(state[journal_id] || %{}, &1))
-    end
-  end
-
-  @impl Adapter
-  def register_account(journal_id, number, _description, _timeout) do
-    send self(), {:registered_account, journal_id, number}
-
-    if exists?(journal_id, number) do
-      {:error, :duplicate}
-    else
-      Agent.update(__MODULE__, &put_account(&1, journal_id, number))
     end
   end
 

--- a/lib/accounting/adapters/test_adapter.ex
+++ b/lib/accounting/adapters/test_adapter.ex
@@ -38,6 +38,12 @@ defmodule Accounting.TestAdapter do
   end
 
   @impl Adapter
+  def setup_account_conversions(journal_id, month, year, accounts, _timeout) do
+    send self(), {:setup_account_conversions, journal_id, month, year, accounts}
+    :ok
+  end
+
+  @impl Adapter
   def list_accounts(journal_id, _timeout) do
     accounts = Agent.get(__MODULE__, fn(state) ->
       state

--- a/lib/accounting/adapters/xero_adapter.ex
+++ b/lib/accounting/adapters/xero_adapter.ex
@@ -170,6 +170,19 @@ defmodule Accounting.XeroAdapter do
     |> handle_http_response()
   end
 
+  @impl Adapter
+  def setup_account_conversions(journal_id, month, year, accounts, timeout) do
+    accounts = for a <- accounts do
+      balance = to_string(a.conversion_balance / 100)
+      [number: a.number, conversion_balance: balance]
+    end
+
+    "setup_account_conversions.xml"
+    |> render(accounts: accounts, month: month, year: year)
+    |> http_client().post("Setup", timeout, creds(journal_id))
+    |> handle_http_response()
+  end
+
   @spec handle_http_response({:ok, HTTPoison.Response.t} | {:error, Elixir.HTTPoison.Error.t}) :: :ok | {:error, :duplicate | HTTPoison.Error.t}
   defp handle_http_response({:ok, %{status_code: 200}}), do: :ok
   defp handle_http_response({:ok, %{status_code: 400, body: "{" <> _ = json} = reasons}) do

--- a/lib/accounting/adapters/xero_adapter/default_http_client.ex
+++ b/lib/accounting/adapters/xero_adapter/default_http_client.ex
@@ -21,6 +21,19 @@ defmodule Accounting.XeroAdapter.DefaultHTTPClient do
   end
 
   @impl XeroAdapter.HTTPClient
+  def post(xml, endpoint, timeout, credentials, params \\ []) do
+    query = URI.encode_query(params)
+    url = "https://api.xero.com/api.xro/2.0/#{endpoint}?#{query}"
+    {oauth_header, _} =
+      "post"
+      |> OAuther.sign(url, [], credentials)
+      |> OAuther.header()
+
+    HTTPoison.put url, xml, [oauth_header, {"Accept", "application/json"}],
+      recv_timeout: timeout
+  end
+
+  @impl XeroAdapter.HTTPClient
   def put(xml, endpoint, timeout, credentials, params \\ []) do
     query = URI.encode_query(params)
     url = "https://api.xero.com/api.xro/2.0/#{endpoint}?#{query}"

--- a/lib/accounting/adapters/xero_adapter/default_http_client.ex
+++ b/lib/accounting/adapters/xero_adapter/default_http_client.ex
@@ -29,7 +29,7 @@ defmodule Accounting.XeroAdapter.DefaultHTTPClient do
       |> OAuther.sign(url, [], credentials)
       |> OAuther.header()
 
-    HTTPoison.put url, xml, [oauth_header, {"Accept", "application/json"}],
+    HTTPoison.post url, xml, [oauth_header, {"Accept", "application/json"}],
       recv_timeout: timeout
   end
 

--- a/lib/accounting/adapters/xero_adapter/http_client.ex
+++ b/lib/accounting/adapters/xero_adapter/http_client.ex
@@ -12,4 +12,6 @@ defmodule Accounting.XeroAdapter.HTTPClient do
   @callback get(endpoint, timeout, credentials, params) :: {:ok, HTTPoison.Response.t} | {:error, HTTPoison.Error.t}
   @callback put(xml, endpoint, timeout, credentials) :: {:ok, HTTPoison.Response.t | HTTPoison.AsyncResponse.t} | {:error, HTTPoison.Error.t}
   @callback put(xml, endpoint, timeout, credentials, params) :: {:ok, HTTPoison.Response.t | HTTPoison.AsyncResponse.t} | {:error, HTTPoison.Error.t}
+  @callback post(xml, endpoint, timeout, credentials) :: {:ok, HTTPoison.Response.t | HTTPoison.AsyncResponse.t} | {:error, HTTPoison.Error.t}
+  @callback post(xml, endpoint, timeout, credentials, params) :: {:ok, HTTPoison.Response.t | HTTPoison.AsyncResponse.t} | {:error, HTTPoison.Error.t}
 end

--- a/lib/accounting/assertions.ex
+++ b/lib/accounting/assertions.ex
@@ -3,7 +3,7 @@ defmodule Accounting.Assertions do
   This module contains a set of assertion functions.
   """
 
-  alias Accounting.{Entry, Journal}
+  alias Accounting.{Account, Entry, Journal}
   import ExUnit.Assertions, only: [flunk: 1]
 
   @timeout 100
@@ -30,6 +30,63 @@ defmodule Accounting.Assertions do
         Unexpected categories were registered:
 
         #{inspect categories}
+        """
+    after
+      @timeout -> true
+    end
+  end
+
+  @spec assert_setup_accounts(Journal.id, [Account.setup, ...]) :: true | no_return
+  def assert_setup_accounts(journal_id, accounts) do
+    receive do
+      {:setup_accounts, ^journal_id, ^accounts} -> true
+    after
+      @timeout ->
+        flunk """
+        Accounts were not registered:
+
+        #{inspect accounts}
+        """
+    end
+  end
+
+  @spec refute_setup_accounts(Journal.id, [Account.setup, ...]) :: true | no_return
+  def refute_setup_accounts(journal_id, accounts) do
+    receive do
+      {:setup_accounts, ^journal_id, ^accounts} ->
+        flunk """
+        Unexpected accounts were registered:
+
+        #{inspect accounts}
+        """
+    after
+      @timeout -> true
+    end
+  end
+
+  @spec assert_setup_account_conversions(Journal.id, 1..12, pos_integer, [Account.setup, ...]) :: true | no_return
+  def assert_setup_account_conversions(journal_id, month, year, accounts) do
+    receive do
+      {:setup_account_conversions, ^journal_id, ^month, ^year, ^accounts} ->
+        true
+    after
+      @timeout ->
+        flunk """
+        Account conversion balances were not set:
+
+        #{inspect accounts}
+        """
+    end
+  end
+
+  @spec refute_setup_account_conversions(Journal.id, 1..12, pos_integer, [Account.setup, ...]) :: true | no_return
+  def refute_setup_account_conversions(journal_id, month, year, accounts) do
+    receive do
+      {:setup_account_conversions, ^journal_id, ^month, ^year, ^accounts} ->
+        flunk """
+        Unexpected account conversion balances were set:
+
+        #{inspect accounts}
         """
     after
       @timeout -> true

--- a/lib/accounting/journal.ex
+++ b/lib/accounting/journal.ex
@@ -17,6 +17,16 @@ defmodule Accounting.Journal do
     %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}}
   end
 
+  @spec setup_accounts(Journal.id, [Account.setup, ...], timeout) :: :ok | {:error, term}
+  def setup_accounts(journal_id, accounts, timeout \\ @default_timeout) do
+    adapter().setup_accounts(journal_id, accounts, timeout)
+  end
+
+  @spec setup_account_conversions(Journal.id, 1..12, pos_integer, [Account.setup, ...], timeout) :: :ok | {:error, term}
+  def setup_account_conversions(journal_id, month, year, accounts, timeout \\ @default_timeout) do
+    adapter().setup_account_conversions(journal_id, month, year, accounts, timeout)
+  end
+
   @spec list_accounts(Journal.id, timeout) :: {:ok, [account_number]} | {:error, term}
   def list_accounts(journal_id, timeout \\ @default_timeout) do
     adapter().list_accounts(journal_id, timeout)
@@ -27,11 +37,6 @@ defmodule Accounting.Journal do
     adapter().fetch_accounts(journal_id, numbers, timeout)
   end
 
-  @spec record_entries(Journal.id, [Entry.t, ...], timeout) :: :ok | {:error, term}
-  def record_entries(journal_id, [_|_] = entries, timeout \\ @default_timeout) do
-    adapter().record_entries(journal_id, entries, timeout)
-  end
-
   @spec register_account(Journal.id, account_number, String.t, timeout) :: :ok | {:error, term}
   def register_account(journal_id, number, description, timeout \\ @default_timeout) do
     adapter().register_account(journal_id, number, description, timeout)
@@ -40,6 +45,11 @@ defmodule Accounting.Journal do
   @spec register_categories(Journal.id, [atom], timeout) :: :ok | {:error, term}
   def register_categories(journal_id, categories, timeout \\ @default_timeout) do
     adapter().register_categories(journal_id, categories, timeout)
+  end
+
+  @spec record_entries(Journal.id, [Entry.t, ...], timeout) :: :ok | {:error, term}
+  def record_entries(journal_id, [_|_] = entries, timeout \\ @default_timeout) do
+    adapter().record_entries(journal_id, entries, timeout)
   end
 
   @spec adapter() :: module

--- a/lib/accounting/views/xero_view.ex
+++ b/lib/accounting/views/xero_view.ex
@@ -15,13 +15,6 @@ defmodule Accounting.XeroView do
   end
 
   @spec render(String.t, keyword) :: String.t
-  def render("register_categories.xml", assigns) do
-    """
-    <Options>
-      #{for category <- assigns[:categories], do: render_category(category)}
-    </Options>
-    """
-  end
   def render("bank_transactions.xml", assigns) do
     """
     <BankTransactions>
@@ -47,6 +40,45 @@ defmodule Accounting.XeroView do
       <Name>#{xml_escape assigns[:name]}</Name>
       <Type>CURRLIAB</Type>
     </Account>
+    """
+  end
+  def render("register_categories.xml", assigns) do
+    """
+    <Options>
+      #{for category <- assigns[:categories], do: render_category(category)}
+    </Options>
+    """
+  end
+  def render("setup_accounts.xml", assigns) do
+    """
+    <Setup>
+      <Accounts>
+        #{for a <- assigns[:accounts], do: render("register_account.xml", a)}
+      </Accounts>
+    </Setup>
+    """
+  end
+  def render("setup_account_conversions.xml", assigns) do
+    """
+    <Setup>
+      <ConversionDate>
+        <Month>#{assigns[:month]}</Month>
+        <Year>#{assigns[:year]}</Year>
+      </ConversionDate>
+      <ConversionBalances>
+        #{for a <- assigns[:accounts], do: render_conversion_accounts(a)}
+      </ConversionBalances>
+    </Setup>
+    """
+  end
+
+  @spec render_conversion_accounts(keyword) :: String.t
+  defp render_conversion_accounts(account) do
+    """
+    <ConversionBalance>
+      <AccountCode>#{xml_escape account[:number]}</AccountCode>
+      <Balance>#{xml_escape account[:conversion_balance]}</Balance>
+    </ConversionBalance>
     """
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Accounting.Mixfile do
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env),
       package: package(),
-      version: "0.10.3",
+      version: "0.10.4",
       start_permanent: Mix.env === :prod,
     ]
   end

--- a/test/accounting/adapter/test_adapter_test.exs
+++ b/test/accounting/adapter/test_adapter_test.exs
@@ -47,10 +47,10 @@ defmodule Accounting.TestAdapterTest do
   test "setup_account_conversions/3" do
     journal_id = :black_and_blue_journal
     accounts = [
-      %Account{number: "R1234", description: "Rob Robertson"},
-      %Account{number: "T1234", description: "Tom Thompson"},
-      %Account{number: "D1234", description: "Don Donaldson"},
-      %Account{number: "J1234", description: "James Jameson"},
+      %Account{number: "R1234", conversion_balance: 1_99},
+      %Account{number: "T1234", conversion_balance: -2_32},
+      %Account{number: "D1234", conversion_balance: 1_54},
+      %Account{number: "J1234", conversion_balance: -6_32},
     ]
 
     assert :ok === TestAdapter.setup_account_conversions(

--- a/test/accounting/adapter/test_adapter_test.exs
+++ b/test/accounting/adapter/test_adapter_test.exs
@@ -9,6 +9,10 @@ defmodule Accounting.TestAdapterTest do
     :ok
   end
 
+  test "setup_accounts/3"
+
+  test "setup_account_conversions/3"
+
   describe "list_accounts/2" do
     test "without any registered accounts" do
       assert {:ok, []} === TestAdapter.list_accounts(:blue_journal, :infinity)

--- a/test/accounting/adapter/test_adapter_test.exs
+++ b/test/accounting/adapter/test_adapter_test.exs
@@ -44,7 +44,27 @@ defmodule Accounting.TestAdapterTest do
     end
   end
 
-  test "setup_account_conversions/3"
+  test "setup_account_conversions/3" do
+    journal_id = :black_and_blue_journal
+    accounts = [
+      %Account{number: "R1234", description: "Rob Robertson"},
+      %Account{number: "T1234", description: "Tom Thompson"},
+      %Account{number: "D1234", description: "Don Donaldson"},
+      %Account{number: "J1234", description: "James Jameson"},
+    ]
+
+    assert :ok === TestAdapter.setup_account_conversions(
+      journal_id, 1, 2017, accounts, :infinity
+    )
+
+    assert_received {
+      :setup_account_conversions,
+      ^journal_id,
+      1,
+      2017,
+      ^accounts
+    }
+  end
 
   describe "list_accounts/2" do
     test "without any registered accounts" do

--- a/test/accounting/adapter/test_adapter_test.exs
+++ b/test/accounting/adapter/test_adapter_test.exs
@@ -9,7 +9,40 @@ defmodule Accounting.TestAdapterTest do
     :ok
   end
 
-  test "setup_accounts/3"
+  describe "setup_accounts/3" do
+    test "creating new accounts" do
+      journal_id = :pink_journal
+      accounts = [
+        %Account{number: "R1234", description: "Rob Robertson"},
+        %Account{number: "T1234", description: "Tom Thompson"},
+        %Account{number: "D1234", description: "Don Donaldson"},
+        %Account{number: "J1234", description: "James Jameson"},
+      ]
+      assert :ok ===
+        TestAdapter.setup_accounts(journal_id, accounts, :infinity)
+
+      assert_received {:setup_accounts, ^journal_id, ^accounts}
+    end
+
+    test "accounts are overwritten" do
+      journal_id = :black_journal
+      number = "F1234"
+      accounts = [
+        %Account{number: "R1234", description: "Rob Robertson"},
+        %Account{number: "T1234", description: "Tom Thompson"},
+        %Account{number: "D1234", description: "Don Donaldson"},
+        %Account{number: "J1234", description: "James Jameson"},
+      ]
+      :ok = TestAdapter.register_account(journal_id, number, nil, :infinity)
+
+      assert {:ok, [number]} === TestAdapter.list_accounts(journal_id, :infinity)
+      assert :ok === TestAdapter.setup_accounts(journal_id, accounts, :infinity)
+      assert {:ok, ["D1234", "J1234", "R1234", "T1234"]} ===
+        TestAdapter.list_accounts(journal_id, :infinity)
+
+      assert_received {:setup_accounts, ^journal_id, ^accounts}
+    end
+  end
 
   test "setup_account_conversions/3"
 

--- a/test/accounting/adapter/test_adapter_test.exs
+++ b/test/accounting/adapter/test_adapter_test.exs
@@ -4,6 +4,8 @@ defmodule Accounting.TestAdapterTest do
 
   alias Accounting.{Account, Entry, LineItem, TestAdapter}
 
+  import Accounting.Assertions
+
   setup do
     {:ok, _} = TestAdapter.start_link([])
     :ok
@@ -21,7 +23,7 @@ defmodule Accounting.TestAdapterTest do
       assert :ok ===
         TestAdapter.setup_accounts(journal_id, accounts, :infinity)
 
-      assert_received {:setup_accounts, ^journal_id, ^accounts}
+      assert_setup_accounts(journal_id, accounts)
     end
 
     test "accounts are overwritten" do
@@ -40,7 +42,7 @@ defmodule Accounting.TestAdapterTest do
       assert {:ok, ["D1234", "J1234", "R1234", "T1234"]} ===
         TestAdapter.list_accounts(journal_id, :infinity)
 
-      assert_received {:setup_accounts, ^journal_id, ^accounts}
+      assert_setup_accounts(journal_id, accounts)
     end
   end
 
@@ -57,13 +59,7 @@ defmodule Accounting.TestAdapterTest do
       journal_id, 1, 2017, accounts, :infinity
     )
 
-    assert_received {
-      :setup_account_conversions,
-      ^journal_id,
-      1,
-      2017,
-      ^accounts
-    }
+    assert_setup_account_conversions(journal_id, 1, 2017, accounts)
   end
 
   describe "list_accounts/2" do

--- a/test/accounting/adapter/xero_adapter_test.exs
+++ b/test/accounting/adapter/xero_adapter_test.exs
@@ -35,6 +35,16 @@ defmodule Accounting.XeroAdapterTest do
     }
   end
 
+  describe "setup_accounts/3" do
+    test "returns HTTPoison errors"
+    test "creates a list of accounts"
+  end
+
+  describe "setup_account_conversions/3" do
+    test "returns HTTPoison errors"
+    test "sets the conversion balance for accounts"
+  end
+
   describe "list_accounts/2" do
     test "returns HTTPoison errors", %{creds: creds, journal_id: journal_id} do
       assert {:error, %HTTPoison.Error{reason: HTTPoison.SuperError}} ===

--- a/test/accounting/adapter/xero_adapter_test.exs
+++ b/test/accounting/adapter/xero_adapter_test.exs
@@ -101,7 +101,7 @@ defmodule Accounting.XeroAdapterTest do
         year: year,
         accounts: [
           [number: "R1234", conversion_balance: "1.99"],
-          [number: "T1233", conversion_balance: "-2.32"],
+          [number: "T1234", conversion_balance: "-2.32"],
         ],
       ]
       assert XeroView.render("setup_account_conversions.xml", assigns) === xml
@@ -121,7 +121,7 @@ defmodule Accounting.XeroAdapterTest do
         year: year,
         accounts: [
           [number: "R1234", conversion_balance: "1.99"],
-          [number: "T1233", conversion_balance: "-2.32"],
+          [number: "T1234", conversion_balance: "-2.32"],
         ],
       ]
       assert XeroView.render("setup_account_conversions.xml", assigns) === xml

--- a/test/accounting/xero_view_test.exs
+++ b/test/accounting/xero_view_test.exs
@@ -54,7 +54,7 @@ defmodule Accounting.XeroViewTest do
           <AccountCode>1</AccountCode>
           <Balance>5.00</Balance>
         </ConversionBalance>
-         <ConversionBalance>
+        <ConversionBalance>
           <AccountCode>2</AccountCode>
           <Balance>-2.00</Balance>
         </ConversionBalance>

--- a/test/accounting/xero_view_test.exs
+++ b/test/accounting/xero_view_test.exs
@@ -2,7 +2,67 @@ defmodule Accounting.XeroViewTest do
   use ExUnit.Case, async: true
   doctest Accounting.Entry
 
-  alias Accounting.{Entry, LineItem, XeroView}
+  alias Accounting.{Account, Entry, LineItem, XeroView}
+
+  test "render setup_accounts.xml" do
+    assigns = [
+      [number: 1, name: "Moe"],
+      [number: 2, name: "Curly"],
+    ]
+
+    xml = """
+    <Setup>
+      <Accounts>
+        <Account>
+          <Code>1</Code>
+          <Name>Moe</Name>
+          <Type>CURRLIAB</Type>
+        </Account>
+        <Account>
+          <Code>2</Code>
+          <Name>Curly</Name>
+          <Type>CURRLIAB</Type>
+        </Account>
+      </Accounts>
+    </Setup>
+    """
+
+    result = XeroView.render("setup_accounts.xml", assigns)
+    assert remove_whitespace(xml) === remove_whitespace(result)
+  end
+
+  test "render setup_account_conversions.xml" do
+    assigns = [
+      month: 1,
+      year: 2014,
+      accounts = [
+        %Account{number: 1, conversion_balance: 5_00},
+        %Account{number: 2, conversion_balance: -2_00},
+      ]
+    ]
+
+    xml = """
+    <Setup>
+      <ConversionDate>
+        <Month>1</Month>
+        <Year>2014</Year>
+      </ConversionDate>
+      <ConversionBalances>
+        <ConversionBalance>
+          <AccountCode>1</AccountCode>
+          <Balance>5.00</Balance>
+        </ConversionBalance>
+         <ConversionBalance>
+          <AccountCode>2</AccountCode>
+          <Balance>-2.00</Balance>
+        </ConversionBalance>
+      </ConversionBalances>
+    </Setup>
+    """
+
+    result = XeroView.render("setup_account_conversions.xml", assigns)
+    assert remove_whitespace(xml) === remove_whitespace(result)
+  end
 
   test "render bank_transactions.xml with a single net-positive entry" do
     line_items = [

--- a/test/accounting/xero_view_test.exs
+++ b/test/accounting/xero_view_test.exs
@@ -2,12 +2,14 @@ defmodule Accounting.XeroViewTest do
   use ExUnit.Case, async: true
   doctest Accounting.Entry
 
-  alias Accounting.{Account, Entry, LineItem, XeroView}
+  alias Accounting.{Entry, LineItem, XeroView}
 
   test "render setup_accounts.xml" do
     assigns = [
-      [number: 1, name: "Moe"],
-      [number: 2, name: "Curly"],
+      accounts: [
+        [number: "1", name: "Moe"],
+        [number: "2", name: "Curly"],
+      ],
     ]
 
     xml = """
@@ -35,10 +37,10 @@ defmodule Accounting.XeroViewTest do
     assigns = [
       month: 1,
       year: 2014,
-      accounts = [
-        %Account{number: 1, conversion_balance: 5_00},
-        %Account{number: 2, conversion_balance: -2_00},
-      ]
+      accounts: [
+        [number: "1", conversion_balance: "5.00"],
+        [number: "2", conversion_balance: "-2.00"],
+      ],
     ]
 
     xml = """

--- a/test/support/stub_xero_adapter_http_client.ex
+++ b/test/support/stub_xero_adapter_http_client.ex
@@ -38,6 +38,17 @@ defmodule StubXeroAdapterHTTPClient do
   end
 
   @impl XeroAdapter.HTTPClient
+  def post(xml, endpoint, timeout, credentials, params \\ [])
+  def post(xml, endpoint, 1 = timeout, credentials, params) do
+    send self(), {:http_post, xml, endpoint, timeout, credentials, params}
+    {:error, %HTTPoison.Error{reason: HTTPoison.SuperError}}
+  end
+  def post(xml, endpoint, timeout, credentials, params) do
+    send self(), {:http_post, xml, endpoint, timeout, credentials, params}
+    {:ok, %HTTPoison.Response{status_code: 200, headers: []}}
+  end
+
+  @impl XeroAdapter.HTTPClient
   def put(xml, endpoint, timeout, credentials, params \\ []) do
     send self(), {:http_put, xml, endpoint, timeout, credentials, params}
     case endpoint do


### PR DESCRIPTION
Why:

* Xero has a specific API endpoint to setup the chart of accounts and
  set the conversion balances.

This change addresses the need by:

* Add `Journal.setup_accounts/2-3`
* Add `Journal.setup_account_conversions/4-5`
* Add ability to easily test the new functions via the TestAdapter.